### PR TITLE
Switch from using Pandoc to Kramdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'kramdown'
-gem 'jekyll-pandoc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,9 +34,6 @@ GEM
       coffee-script (~> 2.2)
     jekyll-gist (1.2.1)
     jekyll-paginate (1.1.0)
-    jekyll-pandoc (1.0.2)
-      jekyll (~> 2.1, >= 2.1.1)
-      pandoc-ruby (~> 1.0, >= 1.0.0)
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)
     jekyll-watch (1.2.1)
@@ -48,7 +45,6 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
-    pandoc-ruby (1.0.0)
     parslet (1.5.0)
       blankslate (~> 2.0)
     posix-spawn (0.3.11)
@@ -72,8 +68,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
-  jekyll-pandoc
   kramdown
 
 BUNDLED WITH
-   1.10.5
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This should be considered a work in progress.  We welcome pull requests and disc
 
 - Ruby (2.2.3 recommended)
 - Bundler gem
-- [Pandoc](http://pandoc.org/installing.html) (try `brew install pandoc` on OS X)
 
 # Usage
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,14 +1,8 @@
 # Base configuration
 permalink: /:title
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
-markdown: pandoc
+markdown: kramdown
 highlighter: pygments
-gems:
-  - jekyll-pandoc
-pandoc:
-  extensions:
-    - normalize
-    - smart
 
 # Title
 name: GovConnect


### PR DESCRIPTION
This commit changes the site to use Kramdown to process markdown instead of pandoc. This is necessary because `pandoc` as a native dep is not supported on Federalist.